### PR TITLE
Automatically generate ngrok link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,9 +134,9 @@ ngrok http 8080
 ## Usage
 
 ```bash
-python3 seeker.py -h
+sudo python3 seeker.py -h   # Always use "sudo" to run seeker.py
 
-usage: seeker.py [-h] [-k KML] [-p PORT] [-u] [-v]
+usage: sudo seeker.py [-h] [-k KML] [-p PORT] [-u] [-v]
 
 options:
   -h, --help            show this help message and exit
@@ -150,7 +150,7 @@ options:
 ##################
 
 # Step 1 : In first terminal
-$ python3 seeker.py
+$ sudo python3 seeker.py
 
 # Step 2 : In second terminal start a tunnel service such as ngrok
 $ ./ngrok http 8080
@@ -163,8 +163,12 @@ $ ./ngrok http 8080
 $ python3 seeker.py -k <filename>
 
 # Use Custom Port
-$ python3 seeker.py -p 1337
+$ sudo python3 seeker.py -p 1337
 $ ./ngrok http 1337
+
+# Automatically start ngrok 
+$ sudo python3 seeker.py -p 1337 -n
+
 
 ################
 # Docker Usage #

--- a/logs/dont't_delete_this_folder.txt
+++ b/logs/dont't_delete_this_folder.txt
@@ -1,0 +1,1 @@
+Please don't delete this folder.

--- a/seeker.py
+++ b/seeker.py
@@ -11,6 +11,7 @@ Y = '\033[33m'  # yellow
 import sys
 import argparse
 import requests
+from pyngrok import ngrok
 import traceback
 from os import path, kill
 from json import loads, decoder
@@ -21,12 +22,14 @@ parser.add_argument('-k', '--kml', help='KML filename')
 parser.add_argument('-p', '--port', type=int, default=8080, help='Web server port [ Default : 8080 ]')
 parser.add_argument('-u', '--update', action='store_true', help='Check for updates')
 parser.add_argument('-v', '--version', action='store_true', help='Prints version')
+parser.add_argument('-n', '--ngrok', action='store_true', help='Generate ngrok url automatically')
 
 args = parser.parse_args()
 kml_fname = args.kml
 port = args.port
 chk_upd = args.update
 print_v = args.version
+is_ngrok = args.ngrok
 
 path_to_script = path.dirname(path.realpath(__file__))
 
@@ -145,6 +148,7 @@ def server():
 	print(f'{G}[+] {C}Starting PHP Server...{W}', end='', flush=True)
 	cmd = ['php', '-S', f'0.0.0.0:{port}', '-t', f'template/{SITE}/']
 
+
 	with open(LOG_FILE, 'w+') as phplog:
 		proc = subp.Popen(cmd, stdout=phplog, stderr=phplog)
 		sleep(3)
@@ -162,6 +166,11 @@ def server():
 				else:
 					print(f'{C}[ {G}✔{C} ]{W}')
 					print()
+
+					if is_ngrok:
+						ngrok_url = str(ngrok.connect(port,'http')).split()[1].split('"')[1]
+						print(f'{G}[+] {C}Ngrok Link - {Y}{ngrok_url}{W}\n')
+			
 			else:
 				print(f'{C}[ {R}Status : {php_sc}{C} ]{W}')
 				cl_quit(proc)


### PR DESCRIPTION
Hi there,
I have modified and added an option in this tool to automatically generate **ngrok** URL which could be quite convenient for the user. Instead of downloading and running **ngrok** in background, now the user can simply run seeker.py in the following way to generate **ngrok** URL - 

```sudo python3 seeker.py -n```

This will generate ngrok URL which the user can later send to the target.

Also, I have modified the **README.md** file so you guys need not to worry about modifying it later :)
One more thing, I have added a folder **logs** which will resolve the issue #383.

Hope, it helps 😀❤

Thank you