### PR TITLE
Add GitHub action to build and push Docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - 'master'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          tags: thewhiteh4t/seeker:latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 db/
 logs/
 template/__pycache__/
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 db/
 logs/
 template/__pycache__/
-.idea/


### PR DESCRIPTION
The [image](https://hub.docker.com/r/thewhiteh4t/seeker) on Docker Hub has not been updated for over a year.

Now Docker Hub free account does not support automatic build, we need to trigger build through GitHub action.

So I added this GitHub action, here's the content reference https://github.com/docker/build-push-action#git-context

To make it available, you need to create two secrets `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN`, the value of `DOCKERHUB_USERNAME` is your Docker Hub username, in this case it might be `thewhiteh4t`, the value of `DOCKERHUB_TOKEN` requires you to create an access token on Docker Hub, you can refer to the link here https://docs.docker.com/docker-hub/access-tokens/#create-an-access-token

Refer: https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository