### PR TITLE
Telegram notification support

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,14 @@
+FROM alpine:latest
+RUN apk update 
+RUN apk add --no-cache \
+git \
+bash \
+python3 \
+py3-pip gcc \
+python3-dev \
+php php-json openssh
+RUN pip3 install requests packaging
+WORKDIR /root/seeker
+COPY . .
+EXPOSE 8080
+ENTRYPOINT ["/root/seeker/seeker.py"]

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ options:
   -t TEMPLATE, --template TEMPLATE      Auto choose the template with the given index
   -d, --debugHTTP                       Disable auto http --> https redirection for testing purposes (only works for the templates having index_temp.html file)
   --telegram                            Send info to a telegram bot, provide telegram token and chat to use (format = token:chatId separated by a colon)
-                                        See details about [how-to send to Telegram bot](./sendToTelegramBot.md)
+                                        (See ./sendToTelegramBot.md)
 
 #########################
 # Environment Variables #
@@ -175,9 +175,8 @@ Variables:
   DISPLAY_URL           Provide the URL to display on the page
   MEM_NUM               Provide the number of group membres (Telegram so far)
   ONLINE_NUM            Provide the number of the group online members (Telegram so far)
-  TELEGRAM              Provide telegram token and chat to use to send info to a telegram bot (format = token:chatId separated by a colon)
-                        See details about [how-to send to Telegram bot](./sendToTelegramBot.md)
-
+  TELEGRAM              Provide telegram token and chat to use to send info to a telegram bot (format = token:chatId separated by a colon) (See ./sendToTelegramBot.md)
+                        
 
 ##################
 # Usage Examples #

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ options:
   -t TEMPLATE, --template TEMPLATE      Auto choose the template with the given index
   -d, --debugHTTP                       Disable auto http --> https redirection for testing purposes (only works for the templates having index_temp.html file)
   --telegram                            Send info to a telegram bot, provide telegram token and chat to use (format = token:chatId separated by a colon)
+                                        See details about [how-to send to Telegram bot](./sendToTelegramBot.md)
 
 #########################
 # Environment Variables #
@@ -174,7 +175,8 @@ Variables:
   DISPLAY_URL           Provide the URL to display on the page
   MEM_NUM               Provide the number of group membres (Telegram so far)
   ONLINE_NUM            Provide the number of the group online members (Telegram so far)
-  TELEGRAM              Provide telegram token and chat to use to send info to a telegram bot (format = token:chatId separated by a colon)  
+  TELEGRAM              Provide telegram token and chat to use to send info to a telegram bot (format = token:chatId separated by a colon)
+                        See details about [how-to send to Telegram bot](./sendToTelegramBot.md)
 
 
 ##################

--- a/README.md
+++ b/README.md
@@ -142,16 +142,17 @@ ngrok http 8080
 ```bash
 python3 seeker.py -h
 
-usage: seeker.py [-h] [-k KML] [-p PORT] [-u] [-v]
+usage: seeker.py [-h] [-k KML] [-p PORT] [-u] [-v] [-t 0] [-d]
 
 options:
-  -h, --help            show this help message and exit
-  -k KML, --kml KML     KML filename
-  -p PORT, --port PORT  Web server port [ Default : 8080 ]
-  -u, --update          Check for updates
-  -v, --version         Prints version
-  -t, --template        Auto choose the template with the given index
-  -d, --debugHTTP       Disable auto http --> https redirection for testing purposes (only works for the templates having index_temp.html file)
+  -h, --help                            show this help message and exit
+  -k KML, --kml KML                     KML filename
+  -p PORT, --port PORT                  Web server port [ Default : 8080 ]
+  -u, --update                          Check for updates
+  -v, --version                         Prints version
+  -t TEMPLATE, --template TEMPLATE      Auto choose the template with the given index
+  -d, --debugHTTP                       Disable auto http --> https redirection for testing purposes (only works for the templates having index_temp.html file)
+  --telegram                            Send info to a telegram bot, provide telegram token and chat to use (format = token:chatId separated by a colon)
 
 #########################
 # Environment Variables #
@@ -173,6 +174,7 @@ Variables:
   DISPLAY_URL           Provide the URL to display on the page
   MEM_NUM               Provide the number of group membres (Telegram so far)
   ONLINE_NUM            Provide the number of the group online members (Telegram so far)
+  TELEGRAM              Provide telegram token and chat to use to send info to a telegram bot (format = token:chatId separated by a colon)  
 
 
 ##################

--- a/README.md
+++ b/README.md
@@ -151,9 +151,10 @@ options:
   -u, --update                          Check for updates
   -v, --version                         Prints version
   -t TEMPLATE, --template TEMPLATE      Auto choose the template with the given index
-  -d, --debugHTTP                       Disable auto http --> https redirection for testing purposes (only works for the templates having index_temp.html file)
-  --telegram                            Send info to a telegram bot, provide telegram token and chat to use (format = token:chatId separated by a colon)
-                                        (See ./sendToTelegramBot.md)
+  -d, --debugHTTP                       Disable auto http --> https redirection for testing purposes 
+                                        (only works for the templates having index_temp.html file)
+  --telegram                            Send info to a telegram bot, provide telegram token and chat to use
+                                        format = token:chatId separated by a colon (See how-to on ./sendToTelegramBot.md)
 
 #########################
 # Environment Variables #
@@ -175,7 +176,8 @@ Variables:
   DISPLAY_URL           Provide the URL to display on the page
   MEM_NUM               Provide the number of group membres (Telegram so far)
   ONLINE_NUM            Provide the number of the group online members (Telegram so far)
-  TELEGRAM              Provide telegram token and chat to use to send info to a telegram bot (format = token:chatId separated by a colon) (See ./sendToTelegramBot.md)
+  TELEGRAM              Provide telegram token and chat to use to send info to a telegram bot
+                        format = token:chatId separated by a colon (See how-to on ./sendToTelegramBot.md)
                         
 
 ##################

--- a/seeker.py
+++ b/seeker.py
@@ -13,6 +13,7 @@ import argparse
 import requests
 import traceback
 import shutil
+import re
 from os import path, kill, mkdir, getenv, environ
 from json import loads, decoder
 from packaging import version
@@ -120,9 +121,10 @@ def sendTelegram(content):
 	if telegram is not None:
 		tmpsplit = telegram.split(':')
 		if len(tmpsplit) <3:
-			utils.print(f'{R}[-] {C}Provided Telegram bot information invalid : expected format is Token:chatId (with colon){W}')
+			utils.print(f'{R}[-] {C}Provided Telegram bot information invalid : expected format is token:chatId (with colon){W}')
 			return
-		r = requests.get('https://api.telegram.org/bot'+tmpsplit[0]+':'+tmpsplit[1]'/sendMessage?chat_id='+tmpsplit[2]+'&text='+urllib.parse.quote_plus(content)
+		content = re.sub('\33\[\d+m', ' ', content)
+		r = requests.get('https://api.telegram.org/bot'+tmpsplit[0]+':'+tmpsplit[1]+'/sendMessage?chat_id='+tmpsplit[2]+'&text='+urllib.parse.quote_plus(content))
 		if r:
 			utils.print(f'{G}[+] {C}Successfully sent to Telegram bot {W}')
 		else:
@@ -320,14 +322,17 @@ def data_parser():
 				sendTelegram(locInfo)
 				utils.print(locInfo)
 				
-
-				utils.print(f'{G}[+] {C}Google Maps : {W}https://www.google.com/maps/place/{var_lat.strip(" deg")}+{var_lon.strip(" deg")}')
+				googleMaps = f'{G}[+] {C}Google Maps : {W}https://www.google.com/maps/place/{var_lat.strip(" deg")}+{var_lon.strip(" deg")}'
+				sendTelegram(googleMaps)
+				utils.print(googleMaps)
 
 				if kml_fname is not None:
 					kmlout(var_lat, var_lon)
 			else:
 				var_err = result_json['error']
-				utils.print(f'{R}[-] {C}{var_err}\n')
+				errmsg = f'{R}[-] {C}{var_err}\n'
+				sendTelegram(errmsg)
+				utils.print(errmsg)
 
 	csvout(data_row)
 	clear()

--- a/seeker.py
+++ b/seeker.py
@@ -119,10 +119,10 @@ def banner():
 def sendTelegram(content):
 	if telegram is not None:
 		tmpsplit = telegram.split(':')
-		if len(tmpsplit) <2:
+		if len(tmpsplit) <3:
 			utils.print(f'{R}[-] {C}Provided Telegram bot information invalid : expected format is Token:chatId (with colon){W}')
 			return
-		r = requests.get('https://api.telegram.org/bot'+tmpsplit[0]+'/sendMessage?chat_id='+tmpsplit[1]+'&text='+urllib.parse.quote_plus(content)
+		r = requests.get('https://api.telegram.org/bot'+tmpsplit[0]+':'+tmpsplit[1]'/sendMessage?chat_id='+tmpsplit[2]+'&text='+urllib.parse.quote_plus(content)
 		if r:
 			utils.print(f'{G}[+] {C}Successfully sent to Telegram bot {W}')
 		else:

--- a/sendToTelegramBot.md
+++ b/sendToTelegramBot.md
@@ -22,6 +22,6 @@ You will find your chat id after the `"chat" :` part, just save it somewhere.
 ## Seeker part
 Append the token of the first step and the chat id of the second one, separated with `:`, the string should have 2 colons symbols `:` (including one existing in the token).
 
-Either use `--telegram` seeker argument or `TELEGRAM` ENV variable to provide the appended content.
+Either use `--telegram` seeker argument or `TELEGRAM` environment variable to provide the appended content.
 
 Then all information/result will be send to you via the telegram bot

--- a/sendToTelegramBot.md
+++ b/sendToTelegramBot.md
@@ -19,7 +19,7 @@ To do so, just replace `{token}` by the token of the first step, in the followin
 
 You will find your chat id after the `"chat" :` part, just save it somewhere.
 
-## Seeker part
+## Seeker
 Append the token of the first step and the chat id of the second one, separated with `:`, the string should have 2 colons symbols `:` (including one existing in the token).
 
 Either use `--telegram` seeker argument or `TELEGRAM` environment variable to provide the appended content.

--- a/sendToTelegramBot.md
+++ b/sendToTelegramBot.md
@@ -1,0 +1,27 @@
+# How-to send information to a Telegram Bot
+## Bot Creation (Telegram Part=
+On Telegram, open a chat with @BotFather
+
+Then write `/newbot` in the chat and send it.
+
+Answer all questions sent by BotFather.
+
+At the end, BotFather, will send you a API Token, save it somewhere.
+
+## Chat ID resolution
+Go in the search bar and search for the bot name you just created.
+
+Click on the start button, send a basic "test" message.
+
+Next, we need to find the Chat ID that exists between you and the bot.
+
+To do so, just replace `{token}` by the token of the first step, in the following url `https://api.telegram.org/bot{token}/getUpdates` and paste it in any web browser.
+
+You will find your chat id after the `"chat" :` part, just save it somewhere.
+
+## Seeker part
+Append the token of the first step and the chat id of the second one, separated with `:`, the string should have 2 colons symbols `:` (including one existing in the token).
+
+Either use `--telegram` seeker argument or `TELEGRAM` ENV variable to provide the appended content.
+
+Then all information/result will be send to you via the telegram bot

--- a/sendToTelegramBot.md
+++ b/sendToTelegramBot.md
@@ -1,5 +1,5 @@
 # How-to send information to a Telegram Bot
-## Bot Creation (Telegram Part=
+## Bot Creation (Telegram Part)
 On Telegram, open a chat with @BotFather
 
 Then write `/newbot` in the chat and send it.


### PR DESCRIPTION
As suggested by https://github.com/thewhiteh4t/seeker/issues/454
Here a change to support telegram notification.
As a pre-requisite, a telegram bot should be created for this use (see sendToTelegramBot.md file), and token and chat id should be retrieved.
Then just provide telegram token & chat Id to seeker : all information/results will be sent to you via telegram, and you will see events directly on your phone