### PR TITLE
Solve issue 464 by removing the extra +

### DIFF
--- a/seeker.py
+++ b/seeker.py
@@ -155,7 +155,7 @@ def send_telegram(content):
 		if rqst:
 			utils.print(f'{G}[+] {C}Successfully sent to Telegram bot {W}')
 		else:
-			utils.print(f'{R}[-] {C}Unable to send to Telegram bot {W}\n{rqst.status_code} => {+rqst.text}')
+			utils.print(f'{R}[-] {C}Unable to send to Telegram bot {W}\n{rqst.status_code} => {rqst.text}')
 
 
 def template_select(site):


### PR DESCRIPTION
Issue https://github.com/thewhiteh4t/seeker/issues/464 shows an unexpected error, this PR improves the error management.

Cause : Error management has been converted from : 
`utils.print(f'{R}[-] {C}Unable to send to Telegram bot {W}'+r.status_code+" => "+r.text)`
to 
`utils.print(f'{R}[-] {C}Unable to send to Telegram bot {W}\n{rqst.status_code} => {+rqst.text}')`

There was an extra "+" sign. 
