### PR TITLE
Add Tunnelmole as a tunneling option

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,16 @@ $ docker run --rm -it --net ngroknet --name seeker thewhiteh4t/seeker
 $ docker run --rm -it --net ngroknet --name ngrok wernight/ngrok ngrok http seeker:8080
 ```
 
+## Tunnelmole tunnels
+Install Tunnelmole with NPM
+```bash
+npm install -g tunnelmole
+```
+Or install a binary for Linux, Mac or Windows at https://tunnelmole.com/install/
+
+tunnelmole 8080
+````
+
 ## Local Tunnels
 Use
 ```


### PR DESCRIPTION
This PR adds [Tunnelmole](https://github.com/robbie-cahill/tunnelmole-client) as a tunneling option.

Tunnelmole is a FOSS tunneling solution with a growing community. It can be self hosted with the [Tunnelmole Service](https://github.com/robbie-cahill/tunnelmole-service) or users can use the hosted service, which is the default. Both the client and service are open source. 