### PR TITLE
Add Docker Compose support with ngrok sidecar

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,0 +1,11 @@
+# seeker
+PORT=8080
+TEMPLATE=1            # pick an index if you want auto-selection
+TITLE=My Invite
+REDIRECT=https://example.com
+TELEGRAM=123456:987654321
+WEBHOOK=https://your-endpoint.example.com/seeker
+
+# ngrok
+NGROK_AUTH=your-ngrok-authtoken
+# NGROK_SUBDOMAIN=your-subdomain   # (paid ngrok plans)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,54 @@
+name: seeker-stack
+
+services:
+  seeker:
+    build: .
+    container_name: seeker
+    restart: unless-stopped
+    # Seeker listens on 8080 by default
+    ports:
+      - "8080:8080"
+    environment:
+      # Mirrors CLI flags / envs supported by seeker.py
+      # (set values in a .env file next to this compose)
+      PORT: "${PORT:-8080}"
+      TEMPLATE: "${TEMPLATE:-}"
+      TITLE: "${TITLE:-}"
+      REDIRECT: "${REDIRECT:-}"
+      IMAGE: "${IMAGE:-}"
+      DESC: "${DESC:-}"
+      SITENAME: "${SITENAME:-}"
+      DISPLAY_URL: "${DISPLAY_URL:-}"
+      MEM_NUM: "${MEM_NUM:-}"
+      ONLINE_NUM: "${ONLINE_NUM:-}"
+      TELEGRAM: "${TELEGRAM:-}"       # format: token:chatId
+      WEBHOOK: "${WEBHOOK:-}"         # unauthenticated POST endpoint
+      DEBUG_HTTP: "${DEBUG_HTTP:-}"   # set to "1" to disable https redirect in supported templates
+    networks:
+      - ngroknet
+    tty: true
+
+  # Simple ngrok sidecar so you get a public URL to the seeker container
+  ngrok:
+    image: wernight/ngrok:latest
+    container_name: ngrok
+    restart: unless-stopped
+    depends_on:
+      - seeker
+    environment:
+      # See ngrok docs — supply your authtoken in .env
+      NGROK_AUTH: "${NGROK_AUTH:-}"
+      # Send traffic to the seeker service on port 8080
+      NGROK_PORT: "seeker:8080"
+      NGROK_PROTOCOL: "http"
+      # optional extras if you want a fixed subdomain on paid plans:
+      # NGROK_SUBDOMAIN: "${NGROK_SUBDOMAIN:-}"
+      # Expose the ngrok web UI on port 4040
+    ports:
+      - "4040:4040"
+    networks:
+      - ngroknet
+
+networks:
+  ngroknet:
+    driver: bridge


### PR DESCRIPTION
This PR introduces a `docker-compose.yml` file to simplify deployment of **Seeker**.
It allows users to quickly bring up the app and expose it via **ngrok** without needing to run manual commands.

### Key Features

* **Seeker service**

  * Builds directly from the repository root.
  * Supports all existing configuration via environment variables (`PORT`, `TEMPLATE`, `TITLE`, `REDIRECT`, `IMAGE`, `DESC`, `SITENAME`, `DISPLAY_URL`, `MEM_NUM`, `ONLINE_NUM`, `TELEGRAM`, `WEBHOOK`, `DEBUG_HTTP`).
  * Maps port `8080` by default.

* **Ngrok service**

  * Provides an automatic HTTPS tunnel to the Seeker container.
  * Configurable via `.env` (`NGROK_AUTH`, `NGROK_SUBDOMAIN`, etc.).
  * Exposes ngrok’s web UI on port `4040` locally for inspection.

* **.env support**

  * Users can define all environment variables in a `.env` file (kept out of version control).
  * Makes configuration easy and reproducible.

### Usage

```bash
# clone repo
git clone https://github.com/thewhiteh4t/seeker.git
cd seeker

# copy and edit env file
cp .env.example .env
# (fill in TELEGRAM, WEBHOOK, NGROK_AUTH, etc.)

# bring up the stack
docker compose up -d --build

# view tunnel info
open http://localhost:4040
```

### Benefits

* Provides a **one-command deployment** (`docker compose up`) for Seeker.
* Reduces manual setup complexity for testing environments.
* Improves accessibility for beginners and for sandbox/CTF usage.
* Keeps all configuration externalized via `.env`.
