### PR TITLE
fix: correct typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Along with Location Information we also get **Device Information** without any p
 
 * Seeker uses HTML API and gets Location Permission and then grabs Longitude and Latitude using GPS Hardware which is present in the device, so Seeker works best with Smartphones, if the GPS Hardware is not present, such as on a Laptop, Seeker fallbacks to IP Geolocation or it will look for Cached Coordinates.  
 
-* Generally if a user accepts location permsission, Accuracy of the information recieved is **accurate to approximately 30 meters**
+* Generally if a user accepts location permission, Accuracy of the information received is **accurate to approximately 30 meters**
 
 * Accuracy depends on multiple factors which you may or may not control such as :
   * Device - Won't work on laptops or phones which have broken GPS
@@ -228,7 +228,7 @@ Use
 ```
 ssh -R 80:localhost:8080 nokey@localhost.run
 ```
-as an alterntive to ngrok
+as an alternative to ngrok
 
 ## Demo
 


### PR DESCRIPTION
## Summary

This PR corrects three typos found in the README.md file:

1. **`permsission` → `permission`** — in the "How is this Different from IP GeoLocation" section
2. **`recieved` → `received`** — in the same section ("Accuracy of the information received")
3. **`alterntive` → `alternative`** — in the "Local Tunnels" section

These are straightforward spelling corrections that improve the readability of the documentation.

## Changes

- Fixed "permsission" → "permission"
- Fixed "recieved" → "received"  
- Fixed "alterntive" → "alternative"

## Testing

These are documentation-only changes and do not affect functionality.